### PR TITLE
docs: add contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Contributing
+
+## Getting Involved
+
+We welcome contributions and are happy to discuss ideas, answer questions, and help you get started.
+
+**Before opening a pull request**, please open an issue or start a discussion with the maintainers. This helps us:
+- Ensure the change aligns with the project's direction
+- Avoid duplicate or conflicting work
+- Provide guidance on implementation approach
+
+We're friendly and responsive—don't hesitate to reach out!
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the project's license.


### PR DESCRIPTION
## Summary
- Adds CONTRIBUTING.md with a "Getting Involved" section encouraging contributors to open issues before PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)